### PR TITLE
removing /mine api on node | Code Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,27 +9,23 @@ I thought that wasn't very cash money and learning to work with JSON objects sou
 The blockchain can be interacted with using either Postman or simple cURL commands to send POST/GET requests to the API to either:
 
 ```
-1. Mine a block /mine 					\\ GET
-```
-![postman mine request](pictures/postman-mine-get.png)
-```
-2. Submit a new transaction /transactions/new 		// POST
+1. Submit a new transaction /transactions/new 		// POST
 ```
 ![wallet sending transaction](pictures/wallet-transaction.png)
 ````
-3. Request the blockchain history /chain 		\\ GET
+2. Request the blockchain history /chain 		\\ GET
 ````
 ![postman chain request](pictures/postman-chain-get.png)
 ``````
-4. Register a new node /nodes/register 			// POST
+3. Register a new node /nodes/register 			// POST
 ``````
 ![syntax for node registration](pictures/postman-node-register.png)
 ``````````
-5. Resolve/update node chain data /nodes/resolve 			\\ GET
+4. Resolve/update node chain data /nodes/resolve 			\\ GET
 ``````````
 ![postman resolve node chain](pictures/postman-resolve-node.png)
 ````````
-6. Receive mined blocks from other nodes /broadcast 	//POST 
+5. Receive mined blocks from other nodes /broadcast 	//POST 
 ````````
 
 install the requirements with
@@ -70,7 +66,7 @@ TO DO
 
 implement signature validation within amount validation for extra security
 
-continue work on the wallet.py, it is currently quite rudimentary.
+continue work on the wallet.py, it is currently quite rudimentary. || WIP
 
 Fix up some of the response codes and json messages between the wallet.py and blockchain.py
 
@@ -81,6 +77,7 @@ Block and transaction broadcast on network || DONE [x]
 balance checking with public/private keys, UTXO's? DONE [x]
 
 a fully hectic PoW algorithm (PoS actually stands for piece of shit)
+Also, finding a more efficient and randomised way of finding proofs so it isnt just the fastest node to find the proof everytime.
 
 an actual personal use case? apart from learning?  || WIP
 

--- a/blockchain.py
+++ b/blockchain.py
@@ -317,73 +317,73 @@ blockchain = Blockchain()
 node_identifier = blockchain.public_key_hash
 
 
-@app.route('/mine', methods=['GET'])
-def mine():
+#@app.route('/mine', methods=['GET'])
+#def mine():
     # We run the proof of work algorithm to get the next proof...
-    last_block = blockchain.last_block
-    last_proof = last_block['proof']
-    proof = blockchain.proof_of_work(last_proof)
+#    last_block = blockchain.last_block
+#    last_proof = last_block['proof']
+#    proof = blockchain.proof_of_work(last_proof)
 
-    unix_time = time()
+#    unix_time = time()
 
-    block_reward_transaction = {
-        'sender': 'Coinbase Reward',
-        'recipient': node_identifier,
-        'amount': 10,
-        'time_submitted': unix_time,
-        'previous_block_hash': blockchain.hash(last_block),
-        'public_key_hex': blockchain.public_key_hex
-    }
+#    block_reward_transaction = {
+#        'sender': 'Coinbase Reward',
+#        'recipient': node_identifier,
+#        'amount': 10,
+#        'time_submitted': unix_time,
+#        'previous_block_hash': blockchain.hash(last_block),
+#        'public_key_hex': blockchain.public_key_hex
+#    }
 
-    hashed_reward = blockchain.calculate_hash(json.dumps(block_reward_transaction, sort_keys=True))
+#    hashed_reward = blockchain.calculate_hash(json.dumps(block_reward_transaction, sort_keys=True))
 
-    block_reward_transaction_with_hash = {
-        'sender': "Coinbase Reward",
-        'recipient': node_identifier,
-        'amount': 10,
-        'time_submitted': block_reward_transaction['time_submitted'],
-        'previous_block_hash': blockchain.hash(last_block),
-        'public_key_hex': blockchain.public_key_hex,
-        'transaction_hash': hashed_reward
-    }
+#    block_reward_transaction_with_hash = {
+#        'sender': "Coinbase Reward",
+#        'recipient': node_identifier,
+#        'amount': 10,
+#        'time_submitted': block_reward_transaction['time_submitted'],
+#        'previous_block_hash': blockchain.hash(last_block),
+#        'public_key_hex': blockchain.public_key_hex,
+#        'transaction_hash': hashed_reward
+#    }
 
-    signature = blockchain.sign(block_reward_transaction_with_hash)
+#    signature = blockchain.sign(block_reward_transaction_with_hash)
 
-    full_block_reward_transaction = {
-        'sender': "Coinbase Reward",
-        'recipient': node_identifier,
-        'amount': 10,
-        'time_submitted': block_reward_transaction['time_submitted'],
-        'previous_block_hash': blockchain.hash(last_block),
-        'public_key_hex': blockchain.public_key_hex,
-        'transaction_hash': hashed_reward,
-        'signature': signature
-    }
-    if Validation.validate_signature(full_block_reward_transaction['public_key_hex'],
-                                     full_block_reward_transaction['signature'], block_reward_transaction_with_hash):
+#    full_block_reward_transaction = {
+#        'sender': "Coinbase Reward",
+#        'recipient': node_identifier,
+#        'amount': 10,
+#        'time_submitted': block_reward_transaction['time_submitted'],
+#        'previous_block_hash': blockchain.hash(last_block),
+#        'public_key_hex': blockchain.public_key_hex,
+#        'transaction_hash': hashed_reward,
+#        'signature': signature
+#    }
+#    if Validation.validate_signature(full_block_reward_transaction['public_key_hex'],
+#                                     full_block_reward_transaction['signature'], block_reward_transaction_with_hash):
         # We must receive a reward for finding the proof.
         # The sender is "0" to signify that this node has mined a new coin.
-        blockchain.new_transaction(full_block_reward_transaction['sender'], full_block_reward_transaction['recipient'],
-                                   full_block_reward_transaction['amount'],
-                                   full_block_reward_transaction['time_submitted'],
-                                   full_block_reward_transaction['previous_block_hash'],
-                                   full_block_reward_transaction['public_key_hex'],
-                                   full_block_reward_transaction['transaction_hash'],
-                                   full_block_reward_transaction['signature'])
+#        blockchain.new_transaction(full_block_reward_transaction['sender'], full_block_reward_transaction['recipient'],
+#                                   full_block_reward_transaction['amount'],
+#                                   full_block_reward_transaction['time_submitted'],
+#                                   full_block_reward_transaction['previous_block_hash'],
+#                                   full_block_reward_transaction['public_key_hex'],
+#                                   full_block_reward_transaction['transaction_hash'],
+#                                   full_block_reward_transaction['signature'])
 
         # Forge the new Block by adding it to the chain
-        previous_hash = blockchain.hash(last_block)
-        block = blockchain.new_block(proof, previous_hash)
+#        previous_hash = blockchain.hash(last_block)
+#        block = blockchain.new_block(proof, previous_hash)
+#
+#        response = {
+#            'message': "New Block Forged",
+#            'index': block['index'],
+#            'transactions': block['transactions'],
+#            'proof': block['proof'],
+#            'previous_hash': block['previous_hash'],
+#        }
 
-        response = {
-            'message': "New Block Forged",
-            'index': block['index'],
-            'transactions': block['transactions'],
-            'proof': block['proof'],
-            'previous_hash': block['previous_hash'],
-        }
-
-    return jsonify(response), 200
+#    return jsonify(response), 200
 
 
 @app.route('/transactions/new', methods=['POST'])


### PR DESCRIPTION
blockchain.py now relies on an external miner to find proofs, the code for /mine is simply commented out for either future use, or should this repo be forked.